### PR TITLE
Update Mac networking host DNS in faq.md

### DIFF
--- a/docs/src/man/faq.md
+++ b/docs/src/man/faq.md
@@ -78,7 +78,7 @@ docker run -it --network=host [container_name] julia
 
 For Mac:
 ```julia
-using Juno; Juno.connect("docker.for.mac.host.internal", [Atom port])
+using Juno; Juno.connect("host.docker.internal", [Atom port])
 ```
 
 For Linux (untested):


### PR DESCRIPTION
Replace deprecated special DNS name used by Docker for Mac with Docker's replacement platform agnostic hostname.