### PR TITLE
Specify need for second icon click in Remote Setup

### DIFF
--- a/docs/src/man/remote.md
+++ b/docs/src/man/remote.md
@@ -11,7 +11,7 @@ Add a new server in `ftp-remote-edit`'s server browser with the `Ftp Remote Edit
 
 ![](../assets/remote3.5.png)
 
-Select that server in the "Remote" tree view and click the planet icon in the toolbar to start a Julia session on the selected remote machine. If you want to start a remote session by default then you can change the `Boot Mode` to `Remote` in the julia-client settings.
+Select that server in the "Remote" tree view and click the planet icon in the toolbar to start a Julia session on the selected remote machine. Click the planet icon a second time to open the remote server terminal. If you want to start a remote session by default then you can change the `Boot Mode` to `Remote` in the julia-client settings.
 
 ![](../assets/remote4.png)
 


### PR DESCRIPTION
For new users of the remote client, the need to click twice is not clear. I didn't realize it was even a feature until I saw it made explicit in a 10 Oct 2019 conversation in the #juno-bridged Julia Slack channel.